### PR TITLE
Add download support

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -2,25 +2,16 @@
 
 set -euo pipefail
 
-# Since we're just going to build from source with `go install` if it's a ref
-# build, the only kind we support right now, there's no download step.
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-#current_script_path=${BASH_SOURCE[0]}
-#plugin_dir=$(dirname "$(dirname "$current_script_path")")
-#
-## shellcheck source=./lib/utils.bash
-#source "${plugin_dir}/lib/utils.bash"
-#
-#mkdir -p "$ASDF_DOWNLOAD_PATH"
-#
-## TODO: Adapt this to proper extension and adapt extracting strategy.
-#release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
-#
-## Download tar.gz file to the download directory
-#download_release "$ASDF_INSTALL_VERSION" "$release_file"
-#
-##  Extract contents of tar.gz file into the download directory
-#tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
-#
-## Remove the tar.gz file since we don't need to keep it
-#rm "$release_file"
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+# file is a standalone binary, not an archive
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
+
+# Download the binary to the download directory, if one exists
+download_release "$ASDF_INSTALL_VERSION" "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -8,10 +8,17 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-mkdir -p "$ASDF_DOWNLOAD_PATH"
+# ref type is build-only
+if [ "$ASDF_INSTALL_TYPE" == "version" ]; then
+	mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# file is a standalone binary, not an archive
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
+	# file is a standalone binary, not an archive
+	release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
 
-# Download the binary to the download directory, if one exists
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+	# Download the binary to the download directory, if one exists
+	download_release "$ASDF_INSTALL_VERSION" "$release_file"
+
+	if [[ -f "$release_file" ]]; then
+		chmod +x "$release_file"
+	fi
+fi

--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,7 @@ if [[ "${ASDF_SUPERDB_DEBUG:-false}" == "true" ]]; then set -x; fi
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=./lib/utils.bash
+# shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -7,7 +7,7 @@ if [[ "${ASDF_SUPERDB_DEBUG:-false}" == "true" ]]; then set -x; fi
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=./lib/utils.bash
+# shellcheck source=../lib/utils.bash
 . "${plugin_dir}/lib/utils.bash"
 
 #curl_opts=(-sI)

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,7 +7,7 @@ if [[ "${ASDF_SUPERDB_DEBUG:-false}" == "true" ]]; then set -x; fi
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=./lib/utils.bash
+# shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo

--- a/contributing.md
+++ b/contributing.md
@@ -10,3 +10,36 @@ asdf plugin test superdb https://github.com/chrismo/asdf-superdb.git "super --ve
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.
+
+## Local Development: Testing Your asdf Plugin
+
+To develop and test your asdf plugin locally, follow these steps:
+
+1. **Remove any existing plugin (if present):**
+   ```bash
+   asdf plugin remove superdb
+   ```
+
+2a. **Add your plugin from your local directory:**
+   ```bash
+   asdf plugin add superdb /full/path/to/your/asdf-superdb
+   ```
+   Replace `/full/path/to/your/asdf-superdb` with the absolute path to your plugin directory.
+
+   This is a one-time copy, so if you make changes to your plugin, you need to remove and re-add it.
+
+2b. **Alternatively, symlink your plugin directory (if supported by your OS):**
+   ```bash
+   ln -s /your/local/asdf-superdb ~/.asdf/plugins/superdb
+   ```
+
+3. **Develop and test in-place:**
+  - Any changes made in your local plugin directory are immediately available to asdf.
+  - Use commands like:
+    ```bash
+    asdf install superdb <version>
+    asdf list superdb
+    ```
+
+4. **If you move your plugin directory:**
+   Remove and re-add the plugin with the new path.


### PR DESCRIPTION
Now that chrismo/superdb-builds exists with releases that can be downloaded for environments where building from sources is not desired, we can attempt to download from there first.